### PR TITLE
Pin upper bound for pyclesperanto-prototype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "matplotlib",
     "apoc",  # dependes on pyclesperanto_prototype still
     "pyclesperanto",
+    "pyclesperanto_prototype<0.24.5", # above pin tries bad import from pycelesperanto 
     "dask",
     "natsort",
     "nbatch>=0.0.3",


### PR DESCRIPTION
# References and relevant issues

Currently, `pyclesperanto-prototype==0.24.5` tries a bad import from `pyclesperanto`.
cf https://github.com/clEsperanto/pyclesperanto/issues/402 https://github.com/clEsperanto/CLIc/issues/522

# Description

The above releases seems like a decent lift to get out the door, so for now I'm going to pin `pyclesperanto-prototype` and revisit later in order to prevent the bad import
